### PR TITLE
Allow to disable a column in a layout + time picker optional seconds

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -2,6 +2,7 @@ library flutter_datetime_picker;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:flutter_datetime_picker/src/datetime_picker_theme.dart';
 import 'package:flutter_datetime_picker/src/date_model.dart';
 import 'package:flutter_datetime_picker/src/i18n_model.dart';
@@ -51,6 +52,7 @@ class DatePicker {
   static Future showTimePicker(
     BuildContext context, {
     bool showTitleActions: true,
+    bool showSecondsColumn : true,
     DateChangedCallback onChanged,
     DateChangedCallback onConfirm,
     locale: LocaleType.en,
@@ -68,7 +70,7 @@ class DatePicker {
             barrierLabel:
                 MaterialLocalizations.of(context).modalBarrierDismissLabel,
             pickerModel:
-                TimePickerModel(currentTime: currentTime, locale: locale)));
+                TimePickerModel(currentTime: currentTime, locale: locale, showSecondsColumn: showSecondsColumn)));
   }
 
   ///
@@ -331,50 +333,62 @@ class _DatePickerState extends State<_DatePickerComponent> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          _renderColumnView(
-              ValueKey(widget.pickerModel.currentLeftIndex()),
-              theme,
-              widget.pickerModel.leftStringAtIndex,
-              leftScrollCtrl,
-              widget.pickerModel.layoutProportions()[0], (index) {
-            widget.pickerModel.setLeftIndex(index);
-          }, (index) {
-            setState(() {
-              refreshScrollOffset();
-              _notifyDateChanged();
-            });
-          }),
+          Container(
+            child: widget.pickerModel.layoutProportions()[0] > 0
+                ? _renderColumnView(
+                    ValueKey(widget.pickerModel.currentLeftIndex()),
+                    theme,
+                    widget.pickerModel.leftStringAtIndex,
+                    leftScrollCtrl,
+                    widget.pickerModel.layoutProportions()[0], (index) {
+                    widget.pickerModel.setLeftIndex(index);
+                  }, (index) {
+                    setState(() {
+                      refreshScrollOffset();
+                      _notifyDateChanged();
+                    });
+                  })
+                : null,
+          ),
           Text(
             widget.pickerModel.leftDivider(),
             style: theme.itemStyle,
           ),
-          _renderColumnView(
-              ValueKey(widget.pickerModel.currentLeftIndex()),
-              theme,
-              widget.pickerModel.middleStringAtIndex,
-              middleScrollCtrl,
-              widget.pickerModel.layoutProportions()[1], (index) {
-            widget.pickerModel.setMiddleIndex(index);
-          }, (index) {
-            setState(() {
-              refreshScrollOffset();
-              _notifyDateChanged();
-            });
-          }),
+          Container(
+            child: widget.pickerModel.layoutProportions()[1] > 0
+                ? _renderColumnView(
+                    ValueKey(widget.pickerModel.currentLeftIndex()),
+                    theme,
+                    widget.pickerModel.middleStringAtIndex,
+                    middleScrollCtrl,
+                    widget.pickerModel.layoutProportions()[1], (index) {
+                    widget.pickerModel.setMiddleIndex(index);
+                  }, (index) {
+                    setState(() {
+                      refreshScrollOffset();
+                      _notifyDateChanged();
+                    });
+                  })
+                : null,
+          ),
           Text(
             widget.pickerModel.rightDivider(),
             style: theme.itemStyle,
           ),
-          _renderColumnView(
-              ValueKey(widget.pickerModel.currentMiddleIndex() +
-                  widget.pickerModel.currentLeftIndex()),
-              theme,
-              widget.pickerModel.rightStringAtIndex,
-              rightScrollCtrl,
-              widget.pickerModel.layoutProportions()[2], (index) {
-            widget.pickerModel.setRightIndex(index);
-            _notifyDateChanged();
-          }, null),
+          Container(
+            child: widget.pickerModel.layoutProportions()[2] > 0
+                ? _renderColumnView(
+                    ValueKey(widget.pickerModel.currentMiddleIndex() +
+                        widget.pickerModel.currentLeftIndex()),
+                    theme,
+                    widget.pickerModel.rightStringAtIndex,
+                    rightScrollCtrl,
+                    widget.pickerModel.layoutProportions()[2], (index) {
+                    widget.pickerModel.setRightIndex(index);
+                    _notifyDateChanged();
+                  }, null)
+                : null,
+          ),
         ],
       ),
     );

--- a/lib/src/date_model.dart
+++ b/lib/src/date_model.dart
@@ -361,7 +361,9 @@ class DatePickerModel extends CommonPickerModel {
 
 //a time picker model
 class TimePickerModel extends CommonPickerModel {
-  TimePickerModel({DateTime currentTime, LocaleType locale})
+  bool showSecondsColumn;
+
+  TimePickerModel({DateTime currentTime, LocaleType locale, this.showSecondsColumn : true})
       : super(locale: locale) {
     this.currentTime = currentTime ?? DateTime.now();
 
@@ -404,7 +406,18 @@ class TimePickerModel extends CommonPickerModel {
 
   @override
   String rightDivider() {
-    return ":";
+    if (showSecondsColumn)
+      return ":";
+    else
+      return "";
+  }
+
+  @override
+  List<int> layoutProportions(){
+    if (showSecondsColumn)
+      return [1,1,1];
+    else
+      return [1,1,0];
   }
 
   @override


### PR DESCRIPTION
Hello, it's me again^^

I noticed that a picker must have 3 columns, but in some case you may want only two (for example in a time picker without the seconds column). 
With this commit, setting a column's layout proportion to 0 will disable the column completely (without needing to do weird proportions like [100, 100, 1]).

That created an opportunity for a "showSecondsColumn" property in the TimePickerModel that would enable/disable the seconds column, so I implemented it too. :) Apparently, this is a feature that is requested by several people: #61 #45 

Finally, I fixed the warnings created by my previous commit.

Have a good day,

Martin


