### PR TITLE
Header Color option for Datetime Picker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -109,12 +109,12 @@ class HomePage extends StatelessWidget {
                       minTime: DateTime(2018, 3, 5),
                       maxTime: DateTime(2019, 6, 7),
                       theme: DatePickerTheme(
-                          backgroundColor: Colors.blue,
-                          itemStyle: TextStyle(
-                              color: Colors.white, fontWeight: FontWeight.bold),
-                          doneStyle:
-                              TextStyle(color: Colors.white, fontSize: 16)),
-                      onChanged: (date) {
+                        backgroundColor: Colors.blue,
+                        headerColor: Colors.green,
+                        itemStyle: TextStyle(
+                            color: Colors.white, fontWeight: FontWeight.bold),
+                        doneStyle: TextStyle(color: Colors.white, fontSize: 16),
+                      ), onChanged: (date) {
                     print('change $date in time zone ' +
                         date.timeZoneOffset.inHours.toString());
                   }, onConfirm: (date) {

--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -43,7 +43,10 @@ class DatePicker {
                 currentTime: currentTime,
                 maxTime: maxTime,
                 minTime: minTime,
-                locale: locale)));
+                locale: locale,
+            ),
+        )
+    );
   }
 
   ///
@@ -200,7 +203,8 @@ class _DatePickerComponent extends StatefulWidget {
       @required this.route,
       this.onChanged,
       this.locale,
-      this.pickerModel});
+      this.pickerModel,
+      });
 
   final DateChangedCallback onChanged;
 
@@ -245,7 +249,8 @@ class _DatePickerState extends State<_DatePickerComponent> {
             child: new CustomSingleChildLayout(
               delegate: new _BottomPickerLayout(
                   widget.route.animation.value, theme,
-                  showTitleActions: widget.route.showTitleActions),
+                  showTitleActions: widget.route.showTitleActions,
+              ),
               child: new GestureDetector(
                 child: Material(
                   color: Colors.transparent,
@@ -384,7 +389,8 @@ class _DatePickerState extends State<_DatePickerComponent> {
             child: widget.pickerModel.layoutProportions()[2] > 0
                 ? _renderColumnView(
                     ValueKey(widget.pickerModel.currentMiddleIndex() +
-                        widget.pickerModel.currentLeftIndex()),
+                        widget.pickerModel.currentLeftIndex(),
+                    ),
                     theme,
                     widget.pickerModel.rightStringAtIndex,
                     rightScrollCtrl,
@@ -406,7 +412,9 @@ class _DatePickerState extends State<_DatePickerComponent> {
 
     return Container(
       height: theme.titleHeight,
-      decoration: BoxDecoration(color: theme.backgroundColor ?? Colors.white),
+      decoration: BoxDecoration(
+        color: theme.headerColor ?? theme.backgroundColor ?? Colors.white,
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[

--- a/lib/src/datetime_picker_theme.dart
+++ b/lib/src/datetime_picker_theme.dart
@@ -6,6 +6,7 @@ class DatePickerTheme extends Diagnosticable {
   final TextStyle doneStyle;
   final TextStyle itemStyle;
   final Color backgroundColor;
+  final Color headerColor;
 
   final double containerHeight;
   final double titleHeight;
@@ -16,6 +17,7 @@ class DatePickerTheme extends Diagnosticable {
     this.doneStyle = const TextStyle(color: Colors.blue, fontSize: 16),
     this.itemStyle = const TextStyle(color: Color(0xFF000046), fontSize: 18),
     this.backgroundColor = Colors.white,
+    this.headerColor,
     this.containerHeight = 210.0,
     this.titleHeight = 44.0,
     this.itemHeight = 36.0,


### PR DESCRIPTION
Header Color option for Datetime Picker

```
                  DatePicker.showDatePicker(context,
                      showTitleActions: true,
                      minTime: DateTime(2018, 3, 5),
                      maxTime: DateTime(2019, 6, 7),
                      theme: DatePickerTheme(
                        backgroundColor: Colors.blue,
                        // I added the option
                        headerColor: Colors.green,
                        itemStyle: TextStyle(
                            color: Colors.white, fontWeight: FontWeight.bold),
                        doneStyle: TextStyle(color: Colors.white, fontSize: 16),
                      ), onChanged: (date) {
                    print('change $date in time zone ' +
                        date.timeZoneOffset.inHours.toString());
                  }, onConfirm: (date) {
                    print('confirm $date');
                  }, currentTime: DateTime.now(), locale: LocaleType.en);
```
<img width="544" alt="Screen Shot 2019-12-05 at 1 15 18" src="https://user-images.githubusercontent.com/396927/70159785-cf143880-16fc-11ea-94a1-f890dd7a8139.png">
