### PR TITLE
Migrate to Diagnosticable mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@
 ## [1.3.2] - add more languages
 ## [1.3.4] - add more languages
 ## [1.3.5] - add 12 hour time picker with AM/PM
+## [1.3.6] - fix error with Diagnosticable in newer Flutter versions

--- a/lib/src/datetime_picker_theme.dart
+++ b/lib/src/datetime_picker_theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class DatePickerTheme extends Diagnosticable {
+class DatePickerTheme with Diagnosticable {
   final TextStyle cancelStyle;
   final TextStyle doneStyle;
   final TextStyle itemStyle;

--- a/lib/src/datetime_picker_theme.dart
+++ b/lib/src/datetime_picker_theme.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class DatePickerTheme with Diagnosticable {
+// Migrate DiagnosticableMixin to Diagnosticable until
+// https://github.com/flutter/flutter/pull/51495 makes it into stable (v1.15.21)
+class DatePickerTheme with DiagnosticableMixin {
   final TextStyle cancelStyle;
   final TextStyle doneStyle;
   final TextStyle itemStyle;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_datetime_picker
 description: A date time picker for flutter, you can choose date / time / date&time in English Dutch and Chinese, and you can also custom your own picker content
-version: 1.3.5
+version: 1.3.6
 homepage: https://github.com/Realank/flutter_datetime_picker
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/Realank/flutter_datetime_picker/issues/120

In the meantime, you can use this until this PR is merged:
```yaml
flutter_datetime_picker:
    git:
      url: https://github.com/Zazo032/flutter_datetime_picker.git
```