### PR TITLE
minTime and maxTime in the same day and hour fix

### DIFF
--- a/lib/src/date_model.dart
+++ b/lib/src/date_model.dart
@@ -564,7 +564,13 @@ class DateTimePickerModel extends CommonPickerModel {
     // TODO: implement setMiddleIndex
     super.setMiddleIndex(index);
     DateTime time = currentTime.add(Duration(days: _currentLeftIndex));
-    if (isAtSameDay(minTime, time) && index == 0) {
+    if (isAtSameDay(minTime, maxTime) && (_currentMiddleIndex + minTime.hour) >= maxTime.hour) {
+      var maxIndex = maxTime.minute;
+      if (_currentRightIndex > maxIndex) {
+        _currentRightIndex = maxIndex;
+      }
+    }
+    else if (isAtSameDay(minTime, time) && index == 0) {
       var maxIndex = 60 - minTime.minute - 1;
       if (_currentRightIndex > maxIndex) {
         _currentRightIndex = maxIndex;
@@ -592,7 +598,14 @@ class DateTimePickerModel extends CommonPickerModel {
   String middleStringAtIndex(int index) {
     if (index >= 0 && index < 24) {
       DateTime time = currentTime.add(Duration(days: _currentLeftIndex));
-      if (isAtSameDay(minTime, time)) {
+      if (isAtSameDay(minTime, maxTime)) {
+        if (index >= 0 && index < (maxTime.hour+1) - minTime.hour) {
+          return digits(minTime.hour + index, 2);
+        } else {
+          return null;
+        }
+      }
+      else if (isAtSameDay(minTime, time)) {
         if (index >= 0 && index < 24 - minTime.hour) {
           return digits(minTime.hour + index, 2);
         } else {
@@ -615,13 +628,37 @@ class DateTimePickerModel extends CommonPickerModel {
   String rightStringAtIndex(int index) {
     if (index >= 0 && index < 60) {
       DateTime time = currentTime.add(Duration(days: _currentLeftIndex));
-      if (isAtSameDay(minTime, time) && _currentMiddleIndex == 0) {
+      if (isAtSameDay(minTime, maxTime) && (_currentMiddleIndex + minTime.hour) >= maxTime.hour) {
+        if (isAtSameDay(minTime, time) && _currentMiddleIndex == 0) {
+          if (index >= 0 && index < 60 - minTime.minute) {
+            int digs = int.parse(digits(minTime.minute + index, 2));
+            if (digs <= maxTime.minute) {
+              return digits(minTime.minute + index, 2);
+            }
+            else {
+              return null;
+            }
+          } else {
+            return null;
+          }
+        }
+        else if (isAtSameDay(maxTime, time) && (_currentMiddleIndex + minTime.hour) >= maxTime.hour) {
+          if (index >= 0 && index <= maxTime.minute) {
+            return digits(index, 2);
+          } else {
+            return null;
+          }
+        }
+        return digits(index, 2);
+      }
+      else if (isAtSameDay(minTime, time) && _currentMiddleIndex == 0) {
         if (index >= 0 && index < 60 - minTime.minute) {
           return digits(minTime.minute + index, 2);
         } else {
           return null;
         }
-      } else if (isAtSameDay(maxTime, time) && _currentMiddleIndex >= maxTime.hour) {
+      }
+      else if (isAtSameDay(maxTime, time) && _currentMiddleIndex >= maxTime.hour) {
         if (index >= 0 && index <= maxTime.minute) {
           return digits(index, 2);
         } else {


### PR DESCRIPTION
Applies for "date-hour-min" user interface.
Not tested with other UI picker variants.

Passing minTime and maxTime parameters that are in the same day causes maxTime hours and minutes to be set to the logical maximum i.e. 23/59.
Passing minTime and maxTime parameters that are in the same hour causes minTime hours and minutes to be set to minimum hour from the parameter and minutes to be set to '0'.

This fix includes:
Correctly set items in list for hour and minutes when minTime and maxTime are in the same day.
Correctly set items in list for hour and minutes when minTime and maxTime are in the same hour.