### PR TITLE
Use the localized am and pm strings in Time12hPickerModel

### DIFF
--- a/lib/src/date_model.dart
+++ b/lib/src/date_model.dart
@@ -457,9 +457,9 @@ class Time12hPickerModel extends CommonPickerModel {
   @override
   String rightStringAtIndex(int index) {
     if (index == 0) {
-      return "AM";
+      return  i18nObjInLocale(this.locale)["am"];
     } else if (index == 1) {
-      return "PM";
+      return i18nObjInLocale(this.locale)["pm"];
     } else {
       return null;
     }


### PR DESCRIPTION
Fixes Realank/flutter_datetime_picker#189 by using the translation of the AM and PM from the locale array.