### PR TITLE
Remove parameter `shadowThemeOnly` from ThemeData

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -212,7 +212,7 @@ class _DatePickerRoute<T> extends PopupRoute<T> {
         pickerModel: pickerModel,
       ),
     );
-    ThemeData inheritTheme = Theme.of(context, shadowThemeOnly: true);
+    ThemeData inheritTheme = Theme.of(context);
     if (inheritTheme != null) {
       bottomSheet = new Theme(data: inheritTheme, child: bottomSheet);
     }


### PR DESCRIPTION
static ThemeData of BuildContext doesn't contain named parameter shadowThemeOnly:tre. From the latest version of Flutter we gets the error:
Error: No named parameter with the name 'shadowThemeOnly'.
    ThemeData inheritTheme = Theme.of(context, shadowThemeOnly: true);