### PR TITLE
Fix spelling mistakes on Catalan language

### DIFF
--- a/lib/src/i18n_model.dart
+++ b/lib/src/i18n_model.dart
@@ -959,7 +959,7 @@ final _i18nModel = {
       'Setembre',
       'Octubre',
       'Novembre',
-      'Decembre'
+      'Desembre'
     ],
     'day': ['Dl', 'Dt', 'Dc', 'Dj', 'Dv', 'Ds', 'Dg'],
     'am': 'AM',


### PR DESCRIPTION
Fix spelling mistake. In catalan the December month is Desembre.