### PR TITLE
Optimized the i18n model lookup.

### DIFF
--- a/lib/src/date_format.dart
+++ b/lib/src/date_format.dart
@@ -283,10 +283,12 @@ String formatDate(DateTime date, List<String> formats, LocaleType locale) {
     } else if (format == m) {
       sb.write(date.month);
     } else if (format == MM) {
-      String monthLong = i18nObjInLocale(locale)['monthLong'][date.month - 1];
+      final monthLong =
+          i18nObjInLocaleLookup(locale, 'monthLong', date.month - 1);
       sb.write(monthLong);
     } else if (format == M) {
-      String monthShort = i18nObjInLocale(locale)['monthShort'][date.month - 1];
+      final monthShort =
+          i18nObjInLocaleLookup(locale, 'monthShort', date.month - 1);
       sb.write(monthShort);
     } else if (format == dd) {
       sb.write(digits(date.day, 2));
@@ -299,7 +301,7 @@ String formatDate(DateTime date, List<String> formats, LocaleType locale) {
     } else if (format == WW) {
       sb.write(digits((dayInYear(date) + 7) ~/ 7, 2));
     } else if (format == D) {
-      String day = i18nObjInLocale(locale)['day'][date.weekday - 1];
+      String day = i18nObjInLocaleLookup(locale, 'day', date.weekday - 1);
       if (locale == LocaleType.ko) {
         day = "($day)";
       }

--- a/lib/src/i18n_model.dart
+++ b/lib/src/i18n_model.dart
@@ -35,8 +35,8 @@ enum LocaleType {
   tw
 }
 
-final _i18nModel = {
-  'kh': {
+final _i18nModel = <LocaleType, Map<String, Object>>{
+  LocaleType.kh: {
     'cancel': 'បោះបង់',
     'done': 'រួចរាល់',
     'today': 'ថ្ងៃនេះ',
@@ -70,9 +70,9 @@ final _i18nModel = {
     ],
     'day': ['ច័ន្ទ', 'អង្គារ', 'ពុធ', 'ព្រហស្បតិ៍', 'សុក្រ', 'សៅរ៍', 'អាទិត្យ'],
     'am': 'ព្រឹក',
-    'pm': 'ថ្ងៃ'
+    'pm': 'ថ្ងៃ',
   },
-  'en': {
+  LocaleType.en: {
     'cancel': 'Cancel',
     'done': 'Done',
     'today': 'Today',
@@ -108,7 +108,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'mn': {
+  LocaleType.mn: {
     'cancel': 'Гарах',
     'done': 'Дуусгах',
     'today': 'Өнөөдөр',
@@ -144,7 +144,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'fa': {
+  LocaleType.fa: {
     'cancel': 'لغو',
     'done': 'تایید',
     'today': 'امروز',
@@ -188,7 +188,7 @@ final _i18nModel = {
     'am': 'صبح',
     'pm': 'عصر'
   },
-  'zh': {
+  LocaleType.zh: {
     //Chinese
     'cancel': '取消',
     'done': '确定',
@@ -225,18 +225,44 @@ final _i18nModel = {
     'am': '上午',
     'pm': '下午'
   },
-  'tw': {
+  LocaleType.tw: {
     //Traditional Chinese
     'cancel': '取消',
     'done': '確定',
     'today': '今天',
-    'monthShort': ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-    'monthLong': ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
+    'monthShort': [
+      '一月',
+      '二月',
+      '三月',
+      '四月',
+      '五月',
+      '六月',
+      '七月',
+      '八月',
+      '九月',
+      '十月',
+      '十一月',
+      '十二月'
+    ],
+    'monthLong': [
+      '一月',
+      '二月',
+      '三月',
+      '四月',
+      '五月',
+      '六月',
+      '七月',
+      '八月',
+      '九月',
+      '十月',
+      '十一月',
+      '十二月'
+    ],
     'day': ['星期一', '星期二', '星期三', '星期四', '星期五', '星期六', '星期日'],
     'am': '上午',
     'pm': '下午'
   },
-  'nl': {
+  LocaleType.nl: {
     //Dutch
     'cancel': 'Annuleer',
     'done': 'Klaar',
@@ -281,7 +307,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'ru': {
+  LocaleType.ru: {
     'cancel': 'Отмена',
     'done': 'Готово',
     'today': 'Сегодня',
@@ -317,7 +343,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'it': {
+  LocaleType.it: {
     'cancel': 'Annulla',
     'done': 'Conferma',
     'today': 'Oggi',
@@ -353,7 +379,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'fr': {
+  LocaleType.fr: {
     'cancel': 'Annuler',
     'done': 'Confirmer',
     'today': "Aujourd'hui",
@@ -389,7 +415,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'gr': {
+  LocaleType.gr: {
     'cancel': 'Άκυρο',
     'done': 'Επιβεβαίωση',
     'today': 'Σήμερα',
@@ -425,7 +451,7 @@ final _i18nModel = {
     'am': 'π.μ',
     'pm': 'μ.μ'
   },
-  'es': {
+  LocaleType.es: {
     'cancel': 'Cancelar',
     'done': 'Confirmar',
     'today': 'Hoy',
@@ -461,7 +487,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'pl': {
+  LocaleType.pl: {
     'cancel': 'Anuluj',
     'done': 'Gotowe',
     'today': 'Dziś',
@@ -497,7 +523,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'pt': {
+  LocaleType.pt: {
     'cancel': 'Cancelar',
     'done': 'Confirmar',
     'today': 'Hoje',
@@ -533,7 +559,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'ko': {
+  LocaleType.ko: {
     'cancel': '취소',
     'done': '완료',
     'today': '오늘',
@@ -569,7 +595,7 @@ final _i18nModel = {
     'am': '오전',
     'pm': '오후'
   },
-  'kk': {
+  LocaleType.kk: {
     'cancel': 'Жою',
     'done': 'Дайын',
     'today': 'бүгін',
@@ -605,7 +631,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'ar': {
+  LocaleType.ar: {
     'cancel': 'إنهاء',
     'done': 'تأكيد',
     'today': 'اليوم',
@@ -649,7 +675,7 @@ final _i18nModel = {
     'am': 'ص',
     'pm': 'م'
   },
-  'tr': {
+  LocaleType.tr: {
     'cancel': 'İptal',
     'done': 'Tamam',
     'today': 'Bugün',
@@ -685,7 +711,7 @@ final _i18nModel = {
     'am': 'ÖÖ',
     'pm': 'ÖS'
   },
-  'az': {
+  LocaleType.az: {
     'cancel': 'Ləğv et',
     'done': 'Bitdi',
     'today': 'Bugün',
@@ -721,7 +747,7 @@ final _i18nModel = {
     'am': 'ÖÖ',
     'pm': 'ÖS'
   },
-  'jp': {
+  LocaleType.jp: {
     //Japanese
     'cancel': 'キャンセル',
     'done': '完了',
@@ -758,7 +784,7 @@ final _i18nModel = {
     'am': '午前',
     'pm': '午後'
   },
-  'de': {
+  LocaleType.de: {
     //German
     'cancel': 'Abbrechen',
     'done': 'OK',
@@ -795,7 +821,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'da': {
+  LocaleType.da: {
 //Danish
     'cancel': 'Annullér',
     'done': 'OK',
@@ -832,7 +858,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'bn': {
+  LocaleType.bn: {
 //Bengali
     'cancel': 'বাতিল',
     'done': 'সম্পন্ন',
@@ -877,7 +903,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'vi': {
+  LocaleType.vi: {
     'cancel': 'Hủy bỏ',
     'done': 'Xong',
     'today': 'Hôm nay',
@@ -913,7 +939,7 @@ final _i18nModel = {
     'am': 'SA',
     'pm': 'CH'
   },
-  'hy': {
+  LocaleType.hy: {
 //Armenian
     'cancel': 'Չեղարկել',
     'done': 'հաստատել',
@@ -950,7 +976,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'id': {
+  LocaleType.id: {
     'cancel': 'Batal',
     'done': 'Pilih',
     'today': 'Hari Ini',
@@ -986,7 +1012,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'bg': {
+  LocaleType.bg: {
     'cancel': 'Отказ',
     'done': 'Готово',
     'today': 'Днес',
@@ -1022,7 +1048,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'eu': {
+  LocaleType.eu: {
     // basque
     'cancel': 'Ezeztau',
     'done': 'Onartu',
@@ -1059,7 +1085,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'cat': {
+  LocaleType.cat: {
     // catalan
     'cancel': 'Cancel·la',
     'done': 'Confirmar',
@@ -1096,7 +1122,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'th': {
+  LocaleType.th: {
     //thai
     'cancel': 'ยกเลิก',
     'done': 'ตกลง',
@@ -1133,7 +1159,7 @@ final _i18nModel = {
     'am': 'AM',
     'pm': 'PM'
   },
-  'si': {
+  LocaleType.si: {
     //Slovenian
     'cancel': 'Prekliči',
     'done': 'V redu',
@@ -1170,7 +1196,7 @@ final _i18nModel = {
     'am': '',
     'pm': ''
   },
-  'no': {
+  LocaleType.no: {
     'cancel': 'Avbryt',
     'done': 'Ferdig',
     'today': 'Idag',
@@ -1206,7 +1232,7 @@ final _i18nModel = {
     'am': '',
     'pm': ''
   },
-  'sq': {
+  LocaleType.sq: {
     'cancel': 'Anulo',
     'done': 'Perfundo',
     'today': 'Sot',
@@ -1242,7 +1268,7 @@ final _i18nModel = {
     'am': 'PD',
     'pm': 'MD'
   },
-  'sv': {
+  LocaleType.sv: {
     'cancel': 'Avbryt',
     'done': 'Klar',
     'today': 'I dag',
@@ -1279,76 +1305,14 @@ final _i18nModel = {
     'pm': 'PM'
   }
 };
-//get international object
-Map<String, dynamic> i18nObjInLocale(LocaleType type) {
-  switch (type) {
-    case LocaleType.fa:
-      return _i18nModel['fa'];
-    case LocaleType.zh:
-      return _i18nModel['zh'];
-    case LocaleType.nl:
-      return _i18nModel['nl'];
-    case LocaleType.ru:
-      return _i18nModel['ru'];
-    case LocaleType.it:
-      return _i18nModel['it'];
-    case LocaleType.fr:
-      return _i18nModel['fr'];
-    case LocaleType.gr:
-      return _i18nModel['gr'];
-    case LocaleType.es:
-      return _i18nModel['es'];
-    case LocaleType.pl:
-      return _i18nModel['pl'];
-    case LocaleType.pt:
-      return _i18nModel['pt'];
-    case LocaleType.ko:
-      return _i18nModel['ko'];
-    case LocaleType.kk:
-      return _i18nModel['kk'];
-    case LocaleType.ar:
-      return _i18nModel['ar'];
-    case LocaleType.tr:
-      return _i18nModel['tr'];
-    case LocaleType.az:
-      return _i18nModel['az'];
-    case LocaleType.jp:
-      return _i18nModel['jp'];
-    case LocaleType.de:
-      return _i18nModel['de'];
-    case LocaleType.da:
-      return _i18nModel['da'];
-    case LocaleType.mn:
-      return _i18nModel['mn'];
-    case LocaleType.bn:
-      return _i18nModel['bn'];
-    case LocaleType.vi:
-      return _i18nModel['vi'];
-    case LocaleType.hy:
-      return _i18nModel['hy'];
-    case LocaleType.id:
-      return _i18nModel['id'];
-    case LocaleType.bg:
-      return _i18nModel['bg'];
-    case LocaleType.eu:
-      return _i18nModel['eu'];
-    case LocaleType.cat:
-      return _i18nModel['cat'];
-    case LocaleType.th:
-      return _i18nModel['th'];
-    case LocaleType.si:
-      return _i18nModel['si'];
-    case LocaleType.no:
-      return _i18nModel['no'];
-    case LocaleType.sq:
-      return _i18nModel['sq'];
-    case LocaleType.sv:
-      return _i18nModel['sv'];
-    case LocaleType.kh:
-      return _i18nModel['kh'];
-    case LocaleType.tw:
-      return _i18nModel['tw'];
-    default:
-      return _i18nModel['en'];
-  }
+
+/// Get international object for [localeType]
+Map<String, Object> i18nObjInLocale(LocaleType localeType) =>
+    _i18nModel[localeType] ?? _i18nModel[LocaleType.en];
+
+/// Get international lookup for a [localeType], [key] and [index].
+String i18nObjInLocaleLookup(LocaleType localeType, String key, int index) {
+  final i18n = i18nObjInLocale(localeType);
+  final i18nKey = i18n[key] as List<String>;
+  return i18nKey[index];
 }


### PR DESCRIPTION
* Revised `_i18nModel` to use `LocaleType` as a key instead of `String`, and then revised `i18nObjInLocale` to do a simple lookup instead of a costly switch statement.
* Added `i18nObjInLocaleLookup` convenience method.
* Note that some code reformatted because _Format on Save_ enabled.
* Replaces PR #209.