### PR TITLE
Fix warning during initialization

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -308,7 +308,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
               ),
               child: GestureDetector(
                 child: Material(
-                  color: theme.backgroundColor ?? Colors.white,
+                  color: theme.backgroundColor,
                   child: _renderPickerView(theme),
                 ),
               ),


### PR DESCRIPTION
Fixes https://github.com/Realank/flutter_datetime_picker/issues/235

If you want to use this:
```yaml
flutter_datetime_picker:
    git:
      url: https://github.com/AlexHartford/flutter_datetime_picker.git
      ref: master
```