### PR TITLE
Revert "Fix warning during initialization"

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -308,7 +308,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
               ),
               child: GestureDetector(
                 child: Material(
-                  color: theme.backgroundColor,
+                  color: theme.backgroundColor ?? Colors.white,
                   child: _renderPickerView(theme),
                 ),
               ),


### PR DESCRIPTION
Reverts Realank/flutter_datetime_picker#236

Apparently DatePickerTheme was updated where backgroundColor is non-nullable, so now this PR created a warning instead of removing it.

```sh
./../../../.pub-cache/hosted/pub.dartlang.org/flutter_datetime_picker-1.5.1/lib/flutter_datetime_picker.dart:311:32: Warning: Operand of null-aware operation '??' has type 'Color' which excludes
null.
 - 'Color' is from 'dart:ui'.
                  color: theme.backgroundColor ?? Colors.white,
```