### PR TITLE
Allow usage of root navigator for showing picker

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -31,9 +31,9 @@ class DatePicker {
     locale: LocaleType.en,
     DateTime? currentTime,
     DatePickerTheme? theme,
+    bool useRootNavigator: false,
   }) async {
-    return await Navigator.push(
-      context,
+    return await Navigator.of(context, rootNavigator: useRootNavigator).push(
       _DatePickerRoute(
         showTitleActions: showTitleActions,
         onChanged: onChanged,
@@ -66,9 +66,9 @@ class DatePicker {
     locale: LocaleType.en,
     DateTime? currentTime,
     DatePickerTheme? theme,
+    bool useRootNavigator: false,
   }) async {
-    return await Navigator.push(
-      context,
+    return await Navigator.of(context, rootNavigator: useRootNavigator).push(
       _DatePickerRoute(
         showTitleActions: showTitleActions,
         onChanged: onChanged,
@@ -99,9 +99,9 @@ class DatePicker {
     locale: LocaleType.en,
     DateTime? currentTime,
     DatePickerTheme? theme,
+    bool useRootNavigator: false,
   }) async {
-    return await Navigator.push(
-      context,
+    return await Navigator.of(context, rootNavigator: useRootNavigator).push(
       _DatePickerRoute(
         showTitleActions: showTitleActions,
         onChanged: onChanged,
@@ -133,9 +133,9 @@ class DatePicker {
     locale: LocaleType.en,
     DateTime? currentTime,
     DatePickerTheme? theme,
+    bool useRootNavigator: false,
   }) async {
-    return await Navigator.push(
-      context,
+    return await Navigator.of(context, rootNavigator: useRootNavigator).push(
       _DatePickerRoute(
         showTitleActions: showTitleActions,
         onChanged: onChanged,
@@ -167,9 +167,9 @@ class DatePicker {
     locale: LocaleType.en,
     BasePickerModel? pickerModel,
     DatePickerTheme? theme,
+    bool useRootNavigator: false,
   }) async {
-    return await Navigator.push(
-      context,
+    return await Navigator.of(context, rootNavigator: useRootNavigator).push(
       _DatePickerRoute(
         showTitleActions: showTitleActions,
         onChanged: onChanged,


### PR DESCRIPTION
In the case that a picker modal is being displayed from a widget which is in a nested navigation controller (for example, if there is a bottom navigation bar), it's helpful to have a useRootNavigator argument on the Picker.showModal method.

This way, when a Picker is displayed from such a widget, it will be shown at the very bottom of the screen, rather than above the bottom navigation bar.