### PR TITLE
- hide material's DatePickerTheme

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide DatePickerTheme;
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 
 void main() => runApp(new MyApp());

--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -2,7 +2,7 @@ library flutter_datetime_picker;
 
 import 'dart:async';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide DatePickerTheme;
 import 'package:flutter/painting.dart';
 import 'package:flutter_datetime_picker/src/datetime_picker_theme.dart';
 import 'package:flutter_datetime_picker/src/date_model.dart';

--- a/lib/src/datetime_picker_theme.dart
+++ b/lib/src/datetime_picker_theme.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide DatePickerTheme;
 
 // Migrate DiagnosticableMixin to Diagnosticable until
 // https://github.com/flutter/flutter/pull/51495 makes it into stable (v1.15.21)


### PR DESCRIPTION
In the new Flutter version (3.10.0), they added DatePickerTheme. So that is why I hide the default DatePickerTheme of Flutter.