### PR TITLE
Fixed DatePickerTheme import collision on Flutter 3.13.4

### DIFF
--- a/lib/flutter_datetime_picker.dart
+++ b/lib/flutter_datetime_picker.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
-import 'package:flutter_datetime_picker/src/datetime_picker_theme.dart';
+import 'package:flutter_datetime_picker/src/datetime_picker_theme.dart' as datepickertheme;
 import 'package:flutter_datetime_picker/src/date_model.dart';
 import 'package:flutter_datetime_picker/src/i18n_model.dart';
 
@@ -30,7 +30,7 @@ class DatePicker {
     DateCancelledCallback? onCancel,
     locale: LocaleType.en,
     DateTime? currentTime,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
   }) async {
     return await Navigator.push(
       context,
@@ -65,7 +65,7 @@ class DatePicker {
     DateCancelledCallback? onCancel,
     locale: LocaleType.en,
     DateTime? currentTime,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
   }) async {
     return await Navigator.push(
       context,
@@ -98,7 +98,7 @@ class DatePicker {
     DateCancelledCallback? onCancel,
     locale: LocaleType.en,
     DateTime? currentTime,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
   }) async {
     return await Navigator.push(
       context,
@@ -132,7 +132,7 @@ class DatePicker {
     DateCancelledCallback? onCancel,
     locale: LocaleType.en,
     DateTime? currentTime,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
   }) async {
     return await Navigator.push(
       context,
@@ -166,7 +166,7 @@ class DatePicker {
     DateCancelledCallback? onCancel,
     locale: LocaleType.en,
     BasePickerModel? pickerModel,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
   }) async {
     return await Navigator.push(
       context,
@@ -191,13 +191,13 @@ class _DatePickerRoute<T> extends PopupRoute<T> {
     this.onChanged,
     this.onConfirm,
     this.onCancel,
-    DatePickerTheme? theme,
+    datepickertheme.DatePickerTheme? theme,
     this.barrierLabel,
     this.locale,
     RouteSettings? settings,
     BasePickerModel? pickerModel,
   })  : this.pickerModel = pickerModel ?? DatePickerModel(),
-        this.theme = theme ?? DatePickerTheme(),
+        this.theme = theme ?? datepickertheme.DatePickerTheme(),
         super(settings: settings);
 
   final bool? showTitleActions;
@@ -205,7 +205,7 @@ class _DatePickerRoute<T> extends PopupRoute<T> {
   final DateChangedCallback? onConfirm;
   final DateCancelledCallback? onCancel;
   final LocaleType? locale;
-  final DatePickerTheme theme;
+  final datepickertheme.DatePickerTheme theme;
   final BasePickerModel pickerModel;
 
   @override
@@ -293,7 +293,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
 
   @override
   Widget build(BuildContext context) {
-    DatePickerTheme theme = widget.route.theme;
+    datepickertheme.DatePickerTheme theme = widget.route.theme;
     return GestureDetector(
       child: AnimatedBuilder(
         animation: widget.route.animation!,
@@ -326,7 +326,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
     }
   }
 
-  Widget _renderPickerView(DatePickerTheme theme) {
+  Widget _renderPickerView(datepickertheme.DatePickerTheme theme) {
     Widget itemView = _renderItemView(theme);
     if (widget.route.showTitleActions == true) {
       return Column(
@@ -341,7 +341,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
 
   Widget _renderColumnView(
     ValueKey key,
-    DatePickerTheme theme,
+    datepickertheme.DatePickerTheme theme,
     StringAtIndexCallBack stringAtIndexCB,
     ScrollController scrollController,
     int layoutProportion,
@@ -396,7 +396,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
     );
   }
 
-  Widget _renderItemView(DatePickerTheme theme) {
+  Widget _renderItemView(datepickertheme.DatePickerTheme theme) {
     return Container(
       color: theme.backgroundColor,
       child: Directionality(
@@ -471,7 +471,7 @@ class _DatePickerState extends State<_DatePickerComponent> {
   }
 
   // Title View
-  Widget _renderTitleActionsView(DatePickerTheme theme) {
+  Widget _renderTitleActionsView(datepickertheme.DatePickerTheme theme) {
     final done = _localeDone();
     final cancel = _localeCancel();
 
@@ -543,7 +543,7 @@ class _BottomPickerLayout extends SingleChildLayoutDelegate {
   final double progress;
   final int? itemCount;
   final bool? showTitleActions;
-  final DatePickerTheme theme;
+  final datepickertheme.DatePickerTheme theme;
   final double bottomPadding;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_datetime_picker
 description: A date time picker for flutter, you can choose date / time / date&time in English Dutch and Chinese, and you can also custom your own picker content
-version: 1.5.1
+version: 1.5.2
 homepage: https://github.com/Realank/flutter_datetime_picker
 
 environment:


### PR DESCRIPTION
The following error pops up while I'm trying to build. I'm fixing it by using aliases.

```
../../.pub-cache/hosted/pub.dev/flutter_datetime_picker-1.5.1/lib/flutter_datetime_picker.dart:199:31: Error: 'DatePickerTheme' is imported from both 'package:flutter/src/material/date_picker_theme.dart' and 'package:flutter_datetime_picker/src/datetime_picker_theme.dart'.
        this.theme = theme ?? DatePickerTheme(),
                              ^^^^^^^^^^^^^^^
Target kernel_snapshot failed: Exception


FAILURE: Build failed with an exception.
```